### PR TITLE
Enable autofs, adauth, pam, lustre_client roles

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -34,6 +34,10 @@
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-collectd, tags: [ 'collectd', 'monitoring' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
+  - { role: ansible-role-adauth, tags: [ 'auth' ] }
+  - { role: ansible-role-pam, tags: [ 'auth' ] }
+  - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }
 
 # Adding a role here? Make sure to add it to local.yml too for the role to be used with ansible-pull
 

--- a/local.yml
+++ b/local.yml
@@ -60,6 +60,10 @@
   - { role: ansible-role-collectd, tags: [ 'collectd', 'monitoring' ] }
 #  - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
   - { role: ansible-role-cuda, tags: [ 'cuda', 'nvidia' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
+  - { role: ansible-role-adauth, tags: [ 'auth' ] }
+  - { role: ansible-role-pam, tags: [ 'auth' ] }
+  - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }
 
 # Adding a role here? Make sure you add it to compute.yml for it to work with ansible push
 

--- a/login.yml
+++ b/login.yml
@@ -44,3 +44,7 @@
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
+  - { role: ansible-role-adauth, tags: [ 'auth' ] }
+  - { role: ansible-role-pam, tags: [ 'auth' ] }
+  - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }


### PR DESCRIPTION
All the roles are disabled by default so that sites who don't need them aren't affected.