### PR TITLE
Add ansible-role-autofs to install and admin

### DIFF
--- a/admin.yml
+++ b/admin.yml
@@ -34,3 +34,4 @@
   - { role: ansible-role-rdma, tags: [ 'rdma', 'infiniband' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }

--- a/install.yml
+++ b/install.yml
@@ -40,6 +40,7 @@
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-pdsh-machines, tags: [ 'pdsh', 'machines' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
  
 - name: grab facts from production nodes
   hosts: production


### PR DESCRIPTION
This is needed for ssh key stuff if the shared directory is mounted by autofs.