### PR TITLE
Use ansible file for touching rather than an external command

### DIFF
--- a/tools/reinstall_computes.yml
+++ b/tools/reinstall_computes.yml
@@ -9,7 +9,7 @@
   
   tasks:
   - name: Create compute node reinstall flag files in Install node
-    command: /bin/touch /var/www/provision/reinstall/{{ item }}
+    file: path=/var/www/provision/reinstall/{{ item }} state=touch
     with_items: groups.compute
 
   - name: Delete known_hosts entries for compute nodes

--- a/tools/reinstall_node.yml
+++ b/tools/reinstall_node.yml
@@ -13,7 +13,7 @@
   
   tasks:
   - name: Create node reinstall flag file in Install node
-    command: /bin/touch /var/www/provision/reinstall/{{ node_name }}
+    file: path=/var/www/provision/reinstall/{{ node_name }} state=touch
 
   - name: Delete known_hosts entry for the node
     lineinfile: dest=/root/.ssh/known_hosts regexp="^{{ node_name }}," state=absent


### PR DESCRIPTION
I stumbled upon this when wondering about why reinstallation fails, which turned out to be due to selinux, but anyway this is a minor improvement.