### PR TITLE
Move autofs role below nfs_mount role

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -21,6 +21,7 @@
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-nhc, tags: [ 'nhc', 'slurm' ] }
   - { role: ansible-role-slurm, tags: [ 'slurm' ] }
@@ -35,7 +36,6 @@
   - { role: ansible-role-collectd, tags: [ 'collectd', 'monitoring' ] }
   - { role: ansible-role-serial-console, tags: [ 'serial', 'console' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
-  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-adauth, tags: [ 'auth' ] }
   - { role: ansible-role-pam, tags: [ 'auth', 'pam' ] }
   - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }

--- a/local.yml
+++ b/local.yml
@@ -46,6 +46,7 @@
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-nhc, tags: [ 'nhc', 'slurm' ] }
   - { role: ansible-role-slurm, tags: [ 'slurm' ] }
@@ -61,7 +62,6 @@
   - { role: ansible-role-serial-console, tags: [ 'serial', 'console' ] }
 #  - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
   - { role: ansible-role-cuda, tags: [ 'cuda', 'nvidia' ] }
-  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-adauth, tags: [ 'auth' ] }
   - { role: ansible-role-pam, tags: [ 'auth', 'pam' ] }
   - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }

--- a/login.yml
+++ b/login.yml
@@ -29,6 +29,7 @@
   - { role: ansible-role-yum-cron-2, tags: [ 'yumcron' ] }
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-squid, tags: [ 'squid' ] }
   - { role: ansible-role-fgci-login, tags: [ 'login'] }  
   - { role: ansible-role-slurm, tags: [ 'slurm' ] }
@@ -44,7 +45,6 @@
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
-  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-adauth, tags: [ 'auth' ] }
   - { role: ansible-role-pam, tags: [ 'auth' ] }
   - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }


### PR DESCRIPTION
The autofs configuration needs to be done at the same time as the nfs mount configuration, as it's an alternative to the static mounts.

As it is, installation fails because NFS is needed for slurm and sshd host keys.