### PR TITLE
Changed role order for autofs.

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -16,6 +16,7 @@
   - { role: ansible-role-yum, tags: [ 'yum', 'repos', 'login' ] }
   - { role: network_interface, tags: [ 'network' ] }
   - { role: ansible-role-ntp, tags: [ 'ntp' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-nis, tags: [ 'nis' ] }
   - { role: ansible-role-adauth, tags: [ 'auth' ] }
   - { role: ansible-role-pam, tags: [ 'auth', 'pam' ] }
@@ -24,7 +25,6 @@
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
-  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-nhc, tags: [ 'nhc', 'slurm' ] }
   - { role: ansible-role-slurm, tags: [ 'slurm' ] }

--- a/install.yml
+++ b/install.yml
@@ -26,6 +26,7 @@
           internal_interface in ansible_interfaces and
           external_interface in ansible_interfaces }
   - { role: ansible-role-ntp, tags: [ 'ntp' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-nis, tags: [ 'nis' ] }
   - { role: ansible-role-nsswitch, tags: [ 'nsswitch', 'auth' ] }
   - { role: ansible-role-pxe_bootstrap, tags: [ 'pxe_bootstrap', 'pxe' ] }
@@ -41,7 +42,6 @@
   - { role: ansible-role-sshd, tags: [ 'sshd', 'ssh' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-pdsh-machines, tags: [ 'pdsh', 'machines' ] }
-  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-adauth, tags: [ 'auth' ] }
   - { role: ansible-role-gitmirror, tags: [ 'gitmirror'] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }

--- a/local.yml
+++ b/local.yml
@@ -41,6 +41,7 @@
   - { role: ansible-role-yum, tags: [ 'yum', 'repos', 'login' ] }
   - { role: network_interface, tags: [ 'network' ] }
   - { role: ansible-role-ntp, tags: [ 'ntp' ] }
+  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-nis, tags: [ 'nis' ] }
   - { role: ansible-role-adauth, tags: [ 'auth' ] }
   - { role: ansible-role-pam, tags: [ 'auth', 'pam' ] }
@@ -49,7 +50,6 @@
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
-  - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-nhc, tags: [ 'nhc', 'slurm' ] }
   - { role: ansible-role-slurm, tags: [ 'slurm' ] }

--- a/requirements.yml
+++ b/requirements.yml
@@ -169,7 +169,7 @@
 
 - src: https://github.com/mhakala/ansible-role-lustre_client
   path: roles
-  version: 54ac06488579ccbb2fea80dfb0f8b87e778154e7
+  version: 5a95c9c20cb37a379f463f36ed062e84b1512139
 
 - src: https://github.com/jabl/ansible-role-pam.git
   path: roles


### PR DESCRIPTION
Autofs has to be run before ssh-keys/slurm/lustre/adauth. Also updated the version for ansible-role-lustre_client. There the mount dir permissions have been updated.