### PR TITLE
Allow setting the DNS resolver search domain

### DIFF
--- a/examples/group_vars/all/all.example
+++ b/examples/group_vars/all/all.example
@@ -27,11 +27,12 @@ internal_net: "10.1.0.0/16"
 
 ib_net_mask: "255.255.0.0"
 
+dns_resolv_search: "{{ intDomain }}.{{ siteDomain }}"
 nameserver1: "10.1.1.2"
 nameserver2: "193.166.4.24"
 nameserver3: "193.166.4.25"
 
-dhcp_common_domain: "fgci.csc.fi"
+dhcp_common_domain: "{{ intDomain }}.{{ siteDomain }}"
 
 enable_ext_nic: "yes"
 enable_int_nic: "yes"

--- a/roles/dns/defaults/main.yml
+++ b/roles/dns/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # defaults for dns role
 
+# To search the cluster internal domain, add
+# dns_resolv_search: "{{ intDomain }}.{{ siteDomain }}"
 nameserver1: "10.0.0.1"
 nameserver2: "10.1.0.1"
 nameserver3: "10.2.0.1"

--- a/roles/dns/templates/resolv.conf.j2
+++ b/roles/dns/templates/resolv.conf.j2
@@ -1,4 +1,7 @@
 # {{ ansible_managed }}
+{% if dns_resolv_search is defined %}
+search {{ dns_resolv_search }}
+{% endif %}
 nameserver {{ nameserver1 }}
 nameserver {{ nameserver2 }}
 nameserver {{ nameserver3 }}


### PR DESCRIPTION
Setting it to the cluster internal domain can be useful, so that short
name lookups first search the cluster internal domain.

Also modifies the example configuration to set the dns_resolv_search
and dhcp_common_domain variables.