### PR TITLE
Added idmapd role

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -24,6 +24,7 @@
   - { role: ansible-role-yum-cron-2, tags: [ 'yumcron' ] }
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
+  - { role: ansible-role-idmapd, tags: [ 'idmapd' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-nhc, tags: [ 'nhc', 'slurm' ] }

--- a/install.yml
+++ b/install.yml
@@ -44,6 +44,7 @@
   - { role: ansible-role-pdsh-machines, tags: [ 'pdsh', 'machines' ] }
   - { role: ansible-role-adauth, tags: [ 'auth' ] }
   - { role: ansible-role-gitmirror, tags: [ 'gitmirror'] }
+  - { role: ansible-role-idmapd, tags: [ 'idmapd'] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
  
 - name: grab facts from production nodes

--- a/local.yml
+++ b/local.yml
@@ -49,6 +49,7 @@
   - { role: ansible-role-yum-cron-2, tags: [ 'yumcron' ] }
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
+  - { role: ansible-role-idmapd, tags: [ 'idmapd' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-nhc, tags: [ 'nhc', 'slurm' ] }

--- a/nfs.yml
+++ b/nfs.yml
@@ -23,6 +23,7 @@
   - { role: ansible-role-nis, tags: [ 'nis' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
   - { role: ansible-role-smartd, tags: [ 'smartd' ] }
+  - { role: ansible-role-idmapd, tags: [ 'idmapd' ] }
   - { role: ansible-role-nfs, tags: [ 'nfs' ] }
   - { role: ansible-role-cvmfs, tags: [ 'cvmfs' ] }
   - { role: ansible-role-rdma, tags: [ 'rdma', 'infiniband' ] }

--- a/requirements.yml
+++ b/requirements.yml
@@ -178,3 +178,11 @@
 - src: https://github.com/jabl/ansible-role-gitmirror.git
   path: roles
   version: acafcaff5094b5d7f9da796096068d62ae895b85
+
+- src: https://github.com/mhakala/ansible-role-idmapd.git
+  path: roles
+  version: 336875424c799846e455004871a77f7655c1f8c6
+
+- src: https://github.com/mhakala/ansible-role-samba.git
+  path: roles
+  version: ca4c6dbca39231e61dbaf07e19d5b7f5b0786d3d


### PR DESCRIPTION
Added idmapd role to compute nodes. Disabled by default. Allows nfsv4 if domain not default dns domain. Also added samba role, that can be used if needed. Not necessary for compute nodes but some sites may benefit from this on e.g. nfs-node.