### PR TITLE
Sync requirements to the install node after pulling

### DIFF
--- a/tools/pullReqs.sh
+++ b/tools/pullReqs.sh
@@ -3,3 +3,6 @@
 #
 
 /usr/bin/ansible-galaxy install -r requirements.yml --force
+
+# Update requirements_mirror.yml for ansible-pull-script
+ansible-playbook install.yml --tags=fgci-install


### PR DESCRIPTION
Otherwise ansible-pull-script might pull old versions and the
configuration becomes inconsistent.