### PR TITLE
Run idmapd role on login node

### DIFF
--- a/login.yml
+++ b/login.yml
@@ -32,6 +32,7 @@
   - { role: ansible-role-yum-cron-2, tags: [ 'yumcron' ] }
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-open-vm-tools, tags: ['open-vm-tools'] }
+  - { role: ansible-role-idmapd, tags: [ 'idmapd' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
   - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-squid, tags: [ 'squid' ] }


### PR DESCRIPTION
All nodes which are NFS clients/servers should also have rpc.idmapd configured.