### PR TITLE
Remove slurm_type

### DIFF
--- a/examples/group_vars/compute/compute.example
+++ b/examples/group_vars/compute/compute.example
@@ -25,8 +25,6 @@ rdma_configure_single_port: True
 networks:
   - "network --onboot=yes --bootproto=dhcp --device={{ internal_interface }} --noipv6"
 
-# Slurm
-slurm_type: "compute"
 # NTP
 ntp_config_server: [ "{{ hostvars[groups['install'][0]]['ansible_hostname'] }}", "{{ hostvars[groups['admin'][0]]['ansible_hostname'] }}" ]
 # DNS

--- a/examples/group_vars/grid/grid.example
+++ b/examples/group_vars/grid/grid.example
@@ -42,9 +42,6 @@ fqdn: "{{siteName}}-grid.{{siteDomain}}"
 networks:
   - "network --onboot={{enable_ext_nic}} --device={{external_interface}} --bootproto=static --ip={{ext_ip_addr}} --netmask={{ext_net_mask}} --nameserver={{nameserver2}} --hostname={{ fqdn }} --gateway={{ext_gateway}} --noipv6"
 
-# Slurm
-slurm_type: "submit"
-
 # Ferm - firewall
 ferm_rules_extra:
  grid:

--- a/examples/group_vars/install/install.example
+++ b/examples/group_vars/install/install.example
@@ -68,8 +68,6 @@ fqdn: "{{siteName}}-install.{{siteDomain}}"
 networks:
   - "network --onboot={{enable_ext_nic}} --device={{external_interface}} --bootproto=static --ip={{ext_ip_addr}} --netmask={{ext_net_mask}} --nameserver={{nameserver2}} --hostname={{ fqdn }} --gateway={{ext_gateway}} --noipv6"
 
-# Slurm
-slurm_type: "service"
 
 # SSHD
 sshd:

--- a/examples/group_vars/login/login.example
+++ b/examples/group_vars/login/login.example
@@ -31,9 +31,6 @@ networks:
 extdefroute: True
 chgIntGW: True
 
-# Slurm
-slurm_type: "submit"
-
 # This makes ansible-role-ferm-firewall restart fail2ban if ferm is reloaded.
 ferm_fail2ban: True
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,7 +2,6 @@
 
 # Order of roles is important
 # vars are documented in https://github.com/CSC-IT-Center-for-Science/fgci-ansible/tree/master/examples
-# slurm_type - we only do the slurm service node tasks because submit/compute depend on the munge key from the service node task.
 
  - hosts: localhost
    remote_user: root


### PR DESCRIPTION
We can remove slurm_type from the example group_vars as well.