### PR TITLE
Set ansible_managed string in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,3 +10,4 @@ hash_behaviour = replace
 forks = 100
 pipelining = True
 gathering = smart
+ansible_managed = Ansible managed file, do not edit directly


### PR DESCRIPTION
By making the ansible_managed string not contain timestamps, usernames
etc. we can avoid ansible considering a file changed and triggering
service restarts needlessly.

See https://github.com/ansible/ansible/issues/5317