### PR TITLE
Force handlers and set ansible_min_version to 2.0

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,3 +11,4 @@ forks = 100
 pipelining = True
 gathering = smart
 ansible_managed = Ansible managed file, do not edit directly
+force_handlers = True

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: MIT
-  min_ansible_version: 1.2
+  min_ansible_version: 2.0
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your 


### PR DESCRIPTION
From http://docs.ansible.com/ansible/playbooks_error_handling.html#handlers-and-failure

: 
"When a task fails on a host, handlers which were previously notified will not be run on that host. This can lead to cases where an unrelated failure can leave a host in an unexpected state. For example, a task could update a configuration file and notify a handler to restart some service. If a task later on in the same play fails, the service will not be restarted despite the configuration change."