### PR TITLE
Configure postfix on compute nodes

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -24,6 +24,7 @@
   - { role: ansible-role-yum-cron-2, tags: [ 'yumcron' ] }
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
+  - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-idmapd, tags: [ 'idmapd' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }

--- a/examples/group_vars/all/all.example
+++ b/examples/group_vars/all/all.example
@@ -160,6 +160,7 @@ dell_install_helper_scripts: False
 
 # Define your SMTP server here
 postfix_relayhost: "smtp.csc.fi"
+postfix_mydomain: "{{ siteDomain }}"
 
 slurm_compute_nodes: "{{ nodeBase }}[1-4]"
 slurm_ExtraParamsList:

--- a/local.yml
+++ b/local.yml
@@ -45,6 +45,7 @@
   - { role: ansible-role-cuda, tags: [ 'cuda', 'nvidia' ] }
   - { role: ansible-role-rsyslog, tags: [ 'rsyslog' ] }
   - { role: ansible-role-aliases, tags: [ 'aliases', 'email' ] }
+  - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-idmapd, tags: [ 'idmapd' ] }
   - { role: ansible-role-nfs_mount, tags: [ 'nfsmount' ] }
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }


### PR DESCRIPTION
Compute nodes run postfix too, so we should configure it. Also set
postfix_mydomain
(https://github.com/CSC-IT-Center-for-Science/ansible-role-postfix/pull/2)
in all.example.