### PR TITLE
enable profile_task callback plugin by default

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -13,3 +13,4 @@ gathering = smart
 ansible_managed = Ansible managed file, do not edit directly
 force_handlers = True
 retry_files_enabled = False
+callback_whitelist = profile_tasks


### PR DESCRIPTION
Question: do we want to enable callback plugin by default?

 - prints the time it takes for each task as well as a summary at the end
 - the output is cluttered after this change and one can't change it much, one can increase the number of tasks shown at the end with environment variable PROFILE_TASKS_TASK_OUTPUT_LIMIT [1]
 - seeing as many updates to ansible lately are about improving the performance this could be useful.

[1]: https://github.com/ansible/ansible/blob/7f8e8ddca9cf103c05bf39d68ebb2e2ded4067f2/lib/ansible/plugins/callback/profile_tasks.py

<pre>
$ ansible-playbook compute.yml -t cuda -D -l gpu

PLAY [grab facts from install nodes] *******************************************
skipping: no hosts matched

PLAY [Compute Nodes] ***********************************************************

TASK [setup] *******************************************************************
Monday 29 August 2016  09:04:41 +0300 (0:00:01.100)       0:00:01.100 ********* 
ok: [gpu]

PLAY [GPU Nodes] ***************************************************************

TASK [ansible-role-cuda : add nvidia CUDA repo] ********************************
Monday 29 August 2016  09:04:43 +0300 (0:00:01.648)       0:00:02.748 ********* 
ok: [gpu]

..SNIP..

TASK [ansible-role-cuda : Initialize the GPUs if there is no /dev/nvidia0] *****
Monday 29 August 2016  09:04:53 +0300 (0:00:00.143)       0:00:12.326 ********* 
skipping: [gpu]

PLAY RECAP *********************************************************************
gpu                        : ok=9    changed=0    unreachable=0    failed=0   

Monday 29 August 2016  09:04:53 +0300 (0:00:00.081)       0:00:12.408 ********* 
=============================================================================== 
ansible-role-cuda : add nvidia CUDA repo -------------------------------- 1.85s
setup ------------------------------------------------------------------- 1.65s
ansible-role-cuda : template in cuda_init.sh used during boot ----------- 1.62s
ansible-role-cuda : template in cuda_init.service systemd script -------- 1.61s
ansible-role-cuda : install cuda software - this is slow - restart if cuda_restart_node_on_install is True --- 1.41s
ansible-role-cuda : enable the cuda_init systemd service ---------------- 1.09s
ansible-role-cuda : make sure cuda_init.sh script is absent from rc.local --- 0.97s
ansible-role-cuda : check if cuda_gpu_name0 ( /dev/nvidia0 ) exists ----- 0.89s
ansible-role-cuda : debug ----------------------------------------------- 0.14s
ansible-role-cuda : Initialize the GPUs if there is no /dev/nvidia0 ----- 0.08s

</pre>