### PR TITLE
Add hosts-int role

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -15,6 +15,7 @@
   - { role: ansible-role-fgci-repo, tags: [ 'fgci7', 'repos' ] }
   - { role: ansible-role-yum, tags: [ 'yum', 'repos', 'login' ] }
   - { role: network_interface, tags: [ 'network' ] }
+  - { role: ansible-role-hosts-int, tags: [ 'hosts'] }
   - { role: ansible-role-ntp, tags: [ 'ntp' ] }
   - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-nis, tags: [ 'nis' ] }

--- a/grid.yml
+++ b/grid.yml
@@ -16,6 +16,7 @@
   - { role: ansible-role-yum, tags: [ 'yum', 'repos' ] }
   - { role: ansible-role-ferm-firewall, tags: [ 'firewall', 'network' ] }
   - { role: network_interface, tags: [ 'network' ] }
+  - { role: ansible-role-hosts-int, tags: [ 'hosts'] }
   - { role: ip_forwarder, tags: [ 'network' ], 
     when: internal_interface is defined and
           external_interface is defined and

--- a/login.yml
+++ b/login.yml
@@ -17,6 +17,7 @@
   - { role: ansible-role-ferm-firewall, tags: [ 'firewall', 'network' ] }
   - { role: ansible-role-fail2ban, tags: [ 'firewall', 'fail2ban', 'network' ] }
   - { role: network_interface, tags: [ 'network' ] }
+  - { role: ansible-role-hosts-int, tags: [ 'hosts'] }
   - { role: ip_forwarder, tags: [ 'network' ], 
     when: internal_interface is defined and
           external_interface is defined and

--- a/nfs.yml
+++ b/nfs.yml
@@ -13,6 +13,7 @@
 
   roles: 
   - { role: network_interface, tags: [ 'network' ] }
+  - { role: ansible-role-hosts-int, tags: [ 'hosts'] }
   - { role: ansible-role-fgci-repo, tags: [ 'fgci7', 'repos' ] }
   - { role: ansible-role-yum, tags: [ 'yum', 'repos', 'login' ] }
   - { role: ansible-role-ferm-firewall, tags: [ 'firewall', 'network' ] }

--- a/requirements.yml
+++ b/requirements.yml
@@ -198,4 +198,4 @@
 
 - src: https://github.com/jabl/ansible-role-hosts-int
   path: roles
-  version: v1.0.1
+  version: v1.0.2

--- a/requirements.yml
+++ b/requirements.yml
@@ -198,4 +198,4 @@
 
 - src: https://github.com/jabl/ansible-role-hosts-int
   path: roles
-  version: v1.0.0
+  version: v1.0.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -196,3 +196,6 @@
   version: v1.0.1
   name: ansible-role-systemd-journal
 
+- src: https://github.com/jabl/ansible-role-hosts-int
+  path: roles
+  version: v1.0.0


### PR DESCRIPTION
This role populates /etc/hosts on the nodes based on the int_ip_addr and ib_ip_addr host variables. Should help https://github.com/CSC-IT-Center-for-Science/fgci-ansible/issues/129.

I'll add the role to local.yml in a follow-up commit, in case you want to wait a while for sites to catch up.