### PR TITLE
Set default network scheduler to fight bufferbloat.

### DIFF
--- a/examples/group_vars/admin/admin.example
+++ b/examples/group_vars/admin/admin.example
@@ -9,6 +9,8 @@ external_interface: "em1"
 
 internal_interface: "em2"
 
+network_scheduler: "fq_codel"
+
 network_ether_interfaces:
   - device: "{{external_interface}}"
     bootproto: "static"

--- a/examples/group_vars/grid/grid.example
+++ b/examples/group_vars/grid/grid.example
@@ -4,6 +4,8 @@ external_interface: "eth0"
 
 internal_interface: "eth1" 
 
+network_scheduler: "fq_codel"
+
 network_ether_interfaces:
   - device: "{{external_interface}}"
     bootproto: "static"

--- a/examples/group_vars/install/install.example
+++ b/examples/group_vars/install/install.example
@@ -6,6 +6,8 @@ internal_interface: "eth1"
 
 admingroup: "admin"
 
+network_scheduler: "fq_codel"
+
 network_ether_interfaces:
   - device: "{{external_interface}}"
     bootproto: "static"

--- a/examples/group_vars/login/login.example
+++ b/examples/group_vars/login/login.example
@@ -4,6 +4,8 @@ internal_interface: "em2"
 external_interface: "em1"
 ib_interface: "ib0"
 
+network_scheduler: "fq_codel"
+
 network_ether_interfaces:
   - device: "{{ib_interface}}"
     bootproto: "static"

--- a/roles/network_interface/defaults/main.yml
+++ b/roles/network_interface/defaults/main.yml
@@ -4,3 +4,9 @@ network_bridge_interfaces: []
 network_bond_interfaces: []
 network_ib_interfaces: []
 network_vlan_interfaces: []
+
+# Default network packet scheduler. Recommendation: fq for hosts,
+# fq_codel for routers. See
+# http://lwn.net/Articles/616241/
+# https://www.bufferbloat.net/projects/codel/wiki/
+network_scheduler: "fq"

--- a/roles/network_interface/tasks/main.yml
+++ b/roles/network_interface/tasks/main.yml
@@ -14,6 +14,13 @@
   environment: env
   when: ansible_os_family == 'Debian'
 
+- name: Set default packet scheduler to reduce bufferbloat
+  sysctl:
+    name=net.core.default_qdisc
+    value="{{ network_scheduler }}"
+    sysctl_file=/etc/sysctl.d/40-bufferbloat.conf
+    sysctl_set=yes
+
 - name: Make sure the include line is there in interfaces file
   lineinfile: >
      regexp="^source\ \/etc\/network\/interfaces.d\/\*"


### PR DESCRIPTION
Set the default network scheduler to "fq". On routers (NAT gateways)
it's recommended to override this and set
network_scheduler="fq_codel".