### PR TITLE
Don't run opensm on compute nodes

### DIFF
--- a/examples/group_vars/compute/compute.example
+++ b/examples/group_vars/compute/compute.example
@@ -21,6 +21,7 @@ network_ether_interfaces:
 
 infiniband_available: True
 rdma_configure_single_port: True
+rdma_manage_opensm: False
 
 networks:
   - "network --onboot=yes --bootproto=dhcp --device={{ internal_interface }} --noipv6"


### PR DESCRIPTION
With lots of hosts, opensm can require a non-trivial amount of CPU
time. So it shouldn't be run on a compute node where it can disturb
batch jobs. Also, with lots of hosts, if all of them run opensm in
standby mode I guess there will be a lot of polling on the network to
check whether the master is still up.