### PR TITLE
Override systemd rpcbind.socket

### DIFF
--- a/admin.yml
+++ b/admin.yml
@@ -36,4 +36,5 @@
   - { role: ansible-role-autofs, tags: [ 'autofs' ] }
   - { role: ansible-role-pdsh-genders, tags: [ 'pdsh', 'genders' ] }
   - { role: ansible-role-systemd-journal, tags: [ 'systemd', 'journal', 'journald' ] }
+  - { role: systemd_rpcbind tags: [ 'systemd', 'rpcbind' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock', 'always' ] }

--- a/compute.yml
+++ b/compute.yml
@@ -58,6 +58,7 @@
   - { role: ansible-role-serial-console, tags: [ 'serial', 'console' ] }
   - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }
   - { role: ansible-role-systemd-journal, tags: [ 'systemd', 'journal', 'journald' ] }
+  - { role: systemd_rpcbind tags: [ 'systemd', 'rpcbind' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock' ] }
 
 # Adding a role here? Make sure to add it to local.yml too for the role to be used with ansible-pull

--- a/grid.yml
+++ b/grid.yml
@@ -42,4 +42,5 @@
   - { role: ansible-role-collectd, tags: [ 'collectd', 'monitoring' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-systemd-journal, tags: [ 'systemd', 'journal', 'journald' ] }
+  - { role: systemd_rpcbind tags: [ 'systemd', 'rpcbind' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock', 'always' ] }

--- a/install.yml
+++ b/install.yml
@@ -47,6 +47,7 @@
   - { role: ansible-role-gitmirror, tags: [ 'gitmirror'] }
   - { role: ansible-role-idmapd, tags: [ 'idmapd'] }
   - { role: ansible-role-systemd-journal, tags: [ 'systemd', 'journal', 'journald' ] }
+  - { role: systemd_rpcbind tags: [ 'systemd', 'rpcbind' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock', 'always' ] }
  
 - name: grab facts from production nodes

--- a/local.yml
+++ b/local.yml
@@ -72,6 +72,7 @@
   - { role: ansible-role-serial-console, tags: [ 'serial', 'console' ] }
   - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }
   - { role: ansible-role-systemd-journal, tags: [ 'systemd', 'journal', 'journald' ] }
+  - { role: systemd_rpcbind tags: [ 'systemd', 'rpcbind' ] }
 
 # Adding a role here? Make sure you add it to compute.yml for it to work with ansible push
 

--- a/login.yml
+++ b/login.yml
@@ -52,5 +52,6 @@
   - { role: ansible-role-sshd-host-keys, tags: [ 'sshd', 'ssh', 'host-keys' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-systemd-journal, tags: [ 'systemd', 'journal', 'journald' ] }
+  - { role: systemd_rpcbind tags: [ 'systemd', 'rpcbind' ] }
   - { role: ansible-role-lustre_client, tags: [ 'lustre' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock', 'always' ] }

--- a/nfs.yml
+++ b/nfs.yml
@@ -33,6 +33,7 @@
   - { role: ansible-role-sshd, tags: [ 'sshd', 'ssh' ] }
   - { role: ansible-role-postfix, tags: [ 'postfix', 'mail' ] }
   - { role: ansible-role-systemd-journal, tags: [ 'systemd', 'journal', 'journald' ] }
+  - { role: systemd_rpcbind tags: [ 'systemd', 'rpcbind' ] }
   - { role: ansible-role-flowdock, tags: [ 'flowdock', 'always' ] }
 
 - name: Mount /home and /scratch on Install Node

--- a/roles/systemd_rpcbind/README.md
+++ b/roles/systemd_rpcbind/README.md
@@ -1,0 +1,6 @@
+systemd_rpcbind
+===============
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1411412
+
+Temporary Workaround

--- a/roles/systemd_rpcbind/defaults/main.yml
+++ b/roles/systemd_rpcbind/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults for systemd_rpcbind
+
+systemd_rpcbind_override: True

--- a/roles/systemd_rpcbind/tasks/main.yml
+++ b/roles/systemd_rpcbind/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: create systemd override directory for rpcbind.socket
+  template:
+    state: directory
+    dest: /etc/systemd/system/rpcbind.socket.d
+    mode: 0755
+    owner: root
+  when: systemd_rpcbind_override
+
+- name: template in an override for rpcbind.socket
+  template:
+    src: systemd_override_rpcbind.socket.j2 
+    dest: /etc/systemd/system/rpcbind.socket.d/override.conf
+    backup: no
+    mode: 0644
+    owner: root
+  when: systemd_rpcbind_override

--- a/roles/systemd_rpcbind/tasks/main.yml
+++ b/roles/systemd_rpcbind/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: create systemd override directory for rpcbind.socket
-  template:
+  file:
     state: directory
     dest: /etc/systemd/system/rpcbind.socket.d
     mode: 0755

--- a/roles/systemd_rpcbind/templates/systemd_override_rpcbind.socket.j2
+++ b/roles/systemd_rpcbind/templates/systemd_override_rpcbind.socket.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+# https://bugzilla.redhat.com/show_bug.cgi?id=1411412
+[Socket]
+ListenStream=
+ListenStream=/var/run/rpcbind.sock
+BindIPv6Only=default

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -79,6 +79,7 @@
      - ansible-role-sshd
      - ansible-role-sshd-host-keys
      - ansible-role-system-limits
+     - systemd_rpcbind
      - ansible-role-users
      - ansible-role-yum-cron-2
 #     - dns


### PR DESCRIPTION
The bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1411412

tldr; rpcbind.socket from rpcbind -38 from EL has some changes which makes dbus unhappy on our clusters. This role reverts that change.

 - new role systemd_rpcbind which is not in requirements.yml but directly in fgci-ansible (because it's a Temporary Workaround [1] and https://github.com/CSC-IT-Center-for-Science/fgci-ansible/commit/edd931409bd708d4bfd17d099498467c241d33d5
 - added to all playbooks https://github.com/CSC-IT-Center-for-Science/fgci-ansible/commit/cfb1015552572c6d91ff5cd2eb4d0145a6b05c0a
 - added to testing https://github.com/CSC-IT-Center-for-Science/fgci-ansible/commit/c9c61d46fcd9b97d585f99ccd92c0fb35c308167

[1]: http://devhumor.com/content/uploads/images/April2016/temporary.jpg