### PR TITLE
Replace wget with rsync in example group_vars

### DIFF
--- a/examples/group_vars/admin/admin.example
+++ b/examples/group_vars/admin/admin.example
@@ -132,7 +132,7 @@ unconfigured_packages:
  - "xorg-x11-xinit"
  - "xvattr"
  - "dejavu-lgc-sans-fonts"
- - "wget"
+ - "rsync"
  - "pciutils"
  - "bash-completion"
  - "smartmontools"

--- a/examples/group_vars/all/fgci-default-packages
+++ b/examples/group_vars/all/fgci-default-packages
@@ -13,8 +13,8 @@ unconfigured_packages:
   - pdsh
   - pciutils
   - perl-Filesys-Df
+  - rsync
   - time
-  - wget
   - yum-plugin-fastestmirror
 
 ib_unconfigured_packages:

--- a/examples/group_vars/compute/compute.example
+++ b/examples/group_vars/compute/compute.example
@@ -140,9 +140,8 @@ kickstart_packages: |
   openmpi
   openssh-server
   perl-Filesys-Df
+  rsync
   subversion
   xerces-c
   yum-plugin-fastestmirror
   Lmod
-  wget
-#  bzip2

--- a/examples/group_vars/compute/fgci-default-packages
+++ b/examples/group_vars/compute/fgci-default-packages
@@ -37,6 +37,7 @@ unconfigured_packages:
   - pciutils
   - pdsh
   - perl-Filesys-Df
+  - rsync
   - smartmontools
   - subversion
   - xerces-c
@@ -44,7 +45,6 @@ unconfigured_packages:
   - net-tools
   - time
   - tcsh
-  - wget
   - fgci-meta-compute
   - bzip2
 

--- a/examples/group_vars/install/install.example
+++ b/examples/group_vars/install/install.example
@@ -91,7 +91,7 @@ unconfigured_packages:
  - git
  - nfs-utils
  - bash-completion
- - wget
+ - rsync
  - pdsh
  - fgci-meta-install
 

--- a/examples/group_vars/nfs/nfs.example
+++ b/examples/group_vars/nfs/nfs.example
@@ -78,7 +78,7 @@ unconfigured_packages:
   - pdsh
   - pciutils
   - perl-Filesys-Df
+  - rsync
   - time
-  - wget
   - yum-plugin-fastestmirror
 


### PR DESCRIPTION
Adding rsync is not strictly necessary, since it's pulled in as a
dependency of git. But lets have it there anyway because it's needed
for ansible-pull-script, just in case the dependency list of git
changes or we decide we no longer need git in the default install.