### PR TITLE
Remove old Tcl environment modules package

### DIFF
--- a/examples/group_vars/all/fgci-default-packages
+++ b/examples/group_vars/all/fgci-default-packages
@@ -23,6 +23,7 @@ ib_unconfigured_packages:
   - infiniband-diags
 
 remove_packages:
+  - environment-modules
   - phonon-backend-gstreamer
   - qt-x11
   - redhat-lsb-graphics

--- a/examples/group_vars/compute/compute.example
+++ b/examples/group_vars/compute/compute.example
@@ -120,7 +120,6 @@ kickstart_packages: |
   gcc-gfortran
   git
   glibc.i686
-  hdf5-openmpi
   @infiniband
   infiniband-diags
   iperf
@@ -132,12 +131,10 @@ kickstart_packages: |
   libstdc++.i686
   libxml2.i686
   mcelog
-  mpitests-openmpi
   netcdf
   nfs-utils
   nscd
   numpy
-  openmpi
   openssh-server
   perl-Filesys-Df
   rsync

--- a/examples/group_vars/compute/fgci-default-packages
+++ b/examples/group_vars/compute/fgci-default-packages
@@ -14,7 +14,6 @@ unconfigured_packages:
   - gcc-gfortran
   - git
   - "glibc.i686"
-  - hdf5-openmpi
   - "@infiniband"
   - infiniband-diags
   - iperf
@@ -26,13 +25,10 @@ unconfigured_packages:
   - "libstdc++.i686"
   - "libxml2.i686"
   - mcelog
-  - mpitests-openmpi
   - netcdf
   - nfs-utils
   - nscd
   - numpy
-  - openmpi
-  - openmpi-devel
   - openssh-server
   - pciutils
   - pdsh
@@ -50,6 +46,7 @@ unconfigured_packages:
   - bzip2
 
 remove_packages:
+  - environment-modules
   - phonon-backend-gstreamer
   - qt-x11
   - redhat-lsb-graphics

--- a/examples/group_vars/login/login.example
+++ b/examples/group_vars/login/login.example
@@ -162,7 +162,6 @@ kickstart_packages: |
   gcc-gfortran
   git
   glibc.i686
-  hdf5-openmpi
   @infiniband
   infiniband-diags
   iperf
@@ -174,12 +173,10 @@ kickstart_packages: |
   libstdc++.i686
   libxml2.i686
   mcelog
-  mpitests-openmpi
   netcdf
   nfs-utils
   nscd
   numpy
-  openmpi
   openssh-server
   perl-Filesys-Df
   rsync

--- a/examples/group_vars/nfs/nfs.example
+++ b/examples/group_vars/nfs/nfs.example
@@ -74,7 +74,6 @@ unconfigured_packages:
   - net-tools
   - nfs-utils
   - nscd
-  - openmpi
   - openssh-server
   - pdsh
   - pciutils


### PR DESCRIPTION
Since FGCI is using Lmod, make sure that the old Tcl environment
modules package is not installed, in order to avoid potential
confusion.